### PR TITLE
Adding needed checks to interactions

### DIFF
--- a/src/commands/dnd/campaign.rs
+++ b/src/commands/dnd/campaign.rs
@@ -229,7 +229,7 @@ pub async fn link(
 }
 
 /// Deletes an existing D&D campaign (DMs only)
-#[poise::command(slash_command)]
+#[poise::command(slash_command, check = "checks::dm_check")]
 pub async fn delete(
     ctx: Context<'_>,
     #[description = "The name of the campaign to delete"]

--- a/src/commands/dnd/campaign/session/response.rs
+++ b/src/commands/dnd/campaign/session/response.rs
@@ -1,5 +1,6 @@
 use crate::models::NewResponse;
 use crate::ops::{response_ops, session_ops};
+use crate::utils::checks;
 use crate::utils::id::user_id_to_i64;
 use crate::{responses, Context, Error};
 
@@ -10,7 +11,7 @@ enum ResponseChoice {
 }
 
 /// Responds to a D&D session
-#[poise::command(slash_command)]
+#[poise::command(slash_command, check = "checks::dnd_check")]
 pub async fn respond(
     ctx: Context<'_>,
     #[description = "The ID of the session you're responding to"] session_id: i32,

--- a/src/commands/settings.rs
+++ b/src/commands/settings.rs
@@ -24,7 +24,12 @@ struct SettingsModal {
 }
 
 /// Configures the settings for the server
-#[poise::command(slash_command, guild_only, category = "Settings")]
+#[poise::command(
+    slash_command,
+    guild_only,
+    category = "Settings",
+    required_permissions = "MANAGE_ROLES"
+)]
 pub async fn settings(ctx: ApplicationContext<'_>) -> Result<(), Error> {
     use poise::Modal as _;
 


### PR DESCRIPTION
Adding a few permissions checks to interactions.

- Adding a `checks::dnd_check` to `/session respond`
- Adding a `checks::dm_check` to `/campaign delete`
- Adding a `required_permissions = "MANAGE_ROLES"` to `/settings`