### PR TITLE
Feature/add auto documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,48 @@
+name: Docs
+on:
+  push:
+    branches: [master]
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+concurrency:
+  group: deploy
+  cancel-in-progress: false
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Configure cache
+        uses: Swatinem/rust-cache@v2
+      - name: Setup pages
+        id: pages
+        uses: actions/configure-pages@v4
+      - name: Clean docs folder
+        run: cargo clean --doc
+      - name: Build docs
+        run: cargo doc
+      - name: Add redirect
+        run: echo '<meta http-equiv="refresh" content="0;url=credit_card_convenience/index.html">' > target/doc/index.html
+      - name: Remove lock file
+        run: rm target/doc/.lock
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: target/doc
+  deploy:
+    name: Deploy
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,7 @@
 name: Docs
 on:
   push:
-    branches: [master]
+    branches: [feature/add-documentation]
 permissions:
   contents: read
   pages: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,7 @@
 name: Docs
 on:
   push:
-    branches: [feature/add-documentation]
+    branches: [master]
 permissions:
   contents: read
   pages: write

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ If you'd like to add this bot to your server, you can [CLICK HERE](https://disco
 
 ## Development
 
+[![Documentation](https://img.shields.io/badge/documentation-visit-blue)](https://dotunwrap.github.io/dm-helper/)
+
 In order to work on this project, you will need to run the following commands:
 
 ```bash


### PR DESCRIPTION
I am requesting a pull into the master branch, but for good reason I think.

The only updates in this pr are twofold,

1st, An update to the readme.md with a little badge that says documentation that contains a hyperlink to the MOST LIKELY URL for the documentation (I had to guess at this since I don't have access to your account, but it should probably work)

2nd, a new github actions workflow has been added to the folder, its rather simple I think but I got it running on some other code, basically it will automatically run 'cargo doc' and then take the generated website and throw it into github pages.

NOTE: SETTINGS MIGHT NEED MODIFICATION on the repo's settings panel make sure that github pages has its source set to "Github Actions" This needs to be done **_PRIOR TO MERGING_**